### PR TITLE
ねくすてーじ vol.6 をNewsに追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yorudokimayu-info",
-  "version": "1.3.47",
+  "version": "1.3.48",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/services/home/InMemoryNewsService.ts
+++ b/src/services/home/InMemoryNewsService.ts
@@ -5,18 +5,18 @@ import { NewsItem, NewsService } from "./NewsService";
 
 export class NewsMaster {
     private text: TranslatableValues;
-    private links?: LinkMaster[];
+    private links: LinkMaster[];
     constructor(props: {text: TranslatableValues, links?: LinkMaster[]}) {
         this.text = props.text;
-        this.links = props.links;
+        this.links = props.links || [];
     }
     getNewsItem(locale: SupportedLocale): NewsItem {
         return {
             text: this.text.getLocalizedValue(locale),
-            links: this.links?.map((linkMaster) => {
+            links: this.links.map((linkMaster) => {
                 return linkMaster.getLinkItem(locale);
-            })
-        }
+            }),
+        };
     }
 }
 
@@ -35,6 +35,13 @@ const newsMasterData: NewsMaster[] = [
                 ]),
             }),
         ],
+    }),
+    new NewsMaster({
+        text: TranslatableValues.create([
+            ['ja', '2025-08-16 ねくすてーじ vol.6'],
+            ['en', '2025-08-16 nextage vol.6'],
+        ]),
+        links: [],
     }),
     new NewsMaster({
         text: TranslatableValues.create([


### PR DESCRIPTION
Close #365


主要な変更

- ねくすてーじ vol.6 をNewsに追加

副次的な変更

- NewsMasterについてlinksプロパティをundefined非許容とした
    - undefinedはJSONにシリアライズできない(nullは可能)のでコンパイルエラーになる
        - 以前はsuperjsonでnullに変換していたが、superjsonはライブラリのバージョン固定が面倒で外した
    - コンストラクタでundefinedの場合はデフォルト値として空配列を入れる