### PR TITLE
人鳥は雷震を運んでをNewsとDiscographyへ追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yorudokimayu-info",
-  "version": "1.3.60",
+  "version": "1.3.61",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/services/discography/InMemoryProductService.test.ts
+++ b/src/services/discography/InMemoryProductService.test.ts
@@ -23,7 +23,7 @@ describe('InMemoryProductService', () => {
             const japaneseTuneCoreLinks = jaSummaries.flatMap((summary) => {
                 return summary.storeLinks.filter((linkItem) => linkItem.url.startsWith("https://linkco.re/"));
             });
-            expect(japaneseTuneCoreLinks.length).toBe(23);
+            expect(japaneseTuneCoreLinks.length).toBe(24);
             japaneseTuneCoreLinks.forEach((link) => {
                 expect(link.url).toContain("lang=ja")
             });
@@ -48,7 +48,7 @@ describe('InMemoryProductService', () => {
             const englishTuneCoreLinks = enSummaries.flatMap((summary) => {
                 return summary.storeLinks.filter((linkItem) => linkItem.url.startsWith("https://linkco.re/"));
             });
-            expect(englishTuneCoreLinks.length).toBe(23);
+            expect(englishTuneCoreLinks.length).toBe(24);
             englishTuneCoreLinks.forEach((link) => {
                 expect(link.url).toContain("lang=en")
             });

--- a/src/services/discography/InMemoryProductService.ts
+++ b/src/services/discography/InMemoryProductService.ts
@@ -70,6 +70,39 @@ export class ProductMaster {
 
 const productMasterData: ProductMaster[] = [
     new ProductMaster({
+        id: "24th-single",
+        name: TranslatableValues.create([
+            ["ja", "人鳥は雷震を運んで"],
+            ["en", "PENGUIN RISING"],
+        ]),
+        kind: "Single",
+        genre: "Alternative",
+        dateOfRelease: new Date("2025-10-10"),
+        description: TranslatableValues.create([
+            ["ja", "活動開始5周年記念"],
+            ["en", "fifth anniversary song"],
+        ]),
+        credits: [
+            TranslatableValues.create([
+                ["ja", "Music 神田ジョン"],
+                ["en", "Music JonKanda"],
+            ]),
+            TranslatableValues.create([
+                ["ja", "Lyrics 山下うみ"],
+                ["en", "Lyrics Yamashita Umi"]
+            ]),
+            TranslatableValues.create([
+                ["ja", "Vocal 拠鳥きまゆ"],
+                ["en", "Vocal KimayuYorudo"],
+            ]),
+        ],
+        mvLinks: [],
+        storeLinks: [
+            LinkMaster.createForTuneCore({id: 'ZMspRA1M'}),
+            LinkMaster.createForOfficialStore({id: '7511323'}),
+        ],
+    }),
+    new ProductMaster({
         id: "23rd-single",
         name: TranslatableValues.create([
             ["ja", "ビリビリビリビリ"],
@@ -164,8 +197,8 @@ const productMasterData: ProductMaster[] = [
                 ["en", "Tr1,3,5 Music / Tr5 Lyrics  Matchy"],
             ]),
             TranslatableValues.create([
-                ["ja", "Tr2 Music/Lyrics 神田ジョン（from PENGUIN RESEARCH）"],
-                ["en", "Tr2 Music/Lyrics John Kanda (from PENGUIN RESEARCH)"],
+                ["ja", "Tr2 Music/Lyrics 神田ジョン"],
+                ["en", "Tr2 Music/Lyrics JonKanda"],
             ]),
             TranslatableValues.create([
                 ["ja", "Tr4 Music/Lyrics 犬絵"],

--- a/src/services/home/InMemoryNewsService.ts
+++ b/src/services/home/InMemoryNewsService.ts
@@ -38,6 +38,16 @@ const newsMasterData: NewsMaster[] = [
     }),
     new NewsMaster({
         text: TranslatableValues.create([
+            ['ja', '2025-10-10 新曲 人鳥は雷震を運んで'],
+            ['en', '2025-10-10 New Single "PENGUIN RISING"'],
+        ]),
+        links: [
+            LinkMaster.createForTuneCore({id: 'ZMspRA1M'}),
+            LinkMaster.createForOfficialStore({id: '7511323'}),
+        ],
+    }),
+    new NewsMaster({
+        text: TranslatableValues.create([
             ['ja', '2025-10-21 #ぶいちゅっ vol.4'],
             ['en', '2025-10-21 Virtual Tuesday vol.4']
         ]),


### PR DESCRIPTION
Close #401

CreditsのenはTuneCoreに準拠した
https://linkco.re/ZMspRA1M?lang=en

For,に関しても同様に修正

