### PR TITLE
storybook関連ライブラリについても8.6.17に更新

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@storybook/addon-actions": "8.6.15",
-    "@storybook/addon-essentials": "8.6.15",
-    "@storybook/addon-interactions": "8.6.15",
-    "@storybook/addon-links": "8.6.15",
-    "@storybook/nextjs": "8.6.15",
-    "@storybook/react": "8.6.15",
+    "@storybook/addon-actions": "8.6.17",
+    "@storybook/addon-essentials": "8.6.17",
+    "@storybook/addon-interactions": "8.6.17",
+    "@storybook/addon-links": "8.6.17",
+    "@storybook/nextjs": "8.6.17",
+    "@storybook/react": "8.6.17",
     "@storybook/testing-library": "^0.2.1",
     "@testing-library/cypress": "10.0.3",
     "@types/jest": "^29.5.0",


### PR DESCRIPTION
https://github.com/human-readable-name/yorudokimayu-info/pull/476 で storybook本体のバージョン指定をした。
関連ライブラリのバージョンが上がってないので、package.jsonを修正