### PR TITLE
chore: ESLintの警告修正

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -19,5 +19,6 @@ jobs:
         run: corepack enable
       - run: yarn install
       - run: yarn lint
+      - run: yarn lint-next
       - run: yarn typecheck
       - run: yarn test

--- a/.storybook/stories/components/common/PageHeader.stories.tsx
+++ b/.storybook/stories/components/common/PageHeader.stories.tsx
@@ -9,8 +9,8 @@ export default {
 } as Meta<typeof PageHeader>;
 
 const Template: StoryFn<typeof PageHeader> = (args) => <PageHeader {...args} />;
-export const pageHeader = Template.bind({});
-pageHeader.args = {
+export const Header = Template.bind({});
+Header.args = {
     currentLocale: 'ja',
     currentPageType: 'Home',
 };

--- a/.storybook/stories/components/discography/DateOfReleaseLabel.stories.tsx
+++ b/.storybook/stories/components/discography/DateOfReleaseLabel.stories.tsx
@@ -9,5 +9,5 @@ export default {
 } as Meta<typeof DateOfRleaseLabel>;
 
 const Template: StoryFn<typeof DateOfRleaseLabel> = (args) => <DateOfRleaseLabel {...args} />;
-export const label = Template.bind({});
-label.args = { dateOfRelease: "2020-10-10"};
+export const Label = Template.bind({});
+Label.args = { dateOfRelease: "2020-10-10"};

--- a/.storybook/stories/components/discography/ProductCard.stories.tsx
+++ b/.storybook/stories/components/discography/ProductCard.stories.tsx
@@ -9,8 +9,8 @@ export default {
 } as Meta<typeof ProductCard>;
 
 const Template: StoryFn<typeof ProductCard> = (args) => <ProductCard {...args} />;
-export const productCard = Template.bind({});
-productCard.args = { 
+export const Card = Template.bind({});
+Card.args = {
     productSummary: {
         id: "1st-ep",
         name: "sparkler",

--- a/.storybook/stories/components/home/News.stories.tsx
+++ b/.storybook/stories/components/home/News.stories.tsx
@@ -9,8 +9,8 @@ export default {
 } as Meta<typeof News>;
 
 const Template: StoryFn<typeof News> = (args) => <News {...args} />;
-export const withNews = Template.bind({});
-withNews.args = {
+export const WithNews = Template.bind({});
+WithNews.args = {
     news: [
         {
             text: "タイトルのみでリンクなし"
@@ -24,7 +24,7 @@ withNews.args = {
         }
     ]
 };
-export const withoutNews = Template.bind({});
-withoutNews.args = {
+export const WithoutNews = Template.bind({});
+WithoutNews.args = {
     news: []
 };

--- a/.storybook/stories/components/home/NewsCard.stories.tsx
+++ b/.storybook/stories/components/home/NewsCard.stories.tsx
@@ -9,15 +9,15 @@ export default {
 } as Meta<typeof NewsCard>;
 
 const Template: StoryFn<typeof NewsCard> = (args) => <NewsCard {...args} />;
-export const withoutLinks = Template.bind({});
-withoutLinks.args = {
+export const WithoutLinks = Template.bind({});
+WithoutLinks.args = {
     newsItem: {
         text: "タイトルのみでリンクなし"
     }
 };
 
-export const withLinks = Template.bind({});
-withLinks.args = {
+export const WithLinks = Template.bind({});
+WithLinks.args = {
     newsItem: {
         text: "タイトルとリンク", 
         links: [

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "next build && next-sitemap --config sitemap.config.js",
     "export": "next export",
     "start": "next start",
-    "lint": "next lint",
+    "lint-next": "next lint",
+    "lint": "eslint",
     "typecheck": "yarn tsc --noEmit",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
@@ -24,6 +25,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
+    "@eslint/eslintrc": "3.3.5",
     "@eslint/js": "9.39.4",
     "@storybook/addon-docs": "10.2.16",
     "@storybook/addon-links": "10.2.16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2067,7 +2067,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/eslintrc@npm:^3.3.5":
+"@eslint/eslintrc@npm:3.3.5, @eslint/eslintrc@npm:^3.3.5":
   version: 3.3.5
   resolution: "@eslint/eslintrc@npm:3.3.5"
   dependencies:
@@ -14869,6 +14869,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "yorudokimayu-info@workspace:."
   dependencies:
+    "@eslint/eslintrc": "npm:3.3.5"
     "@eslint/js": "npm:9.39.4"
     "@storybook/addon-docs": "npm:10.2.16"
     "@storybook/addon-links": "npm:10.2.16"


### PR DESCRIPTION
refs #481

- StorybookのexportはPascalCaseにした
- @eslint/eslintrc のインストールが漏れていたので追加
- scriptsのlintをeslint実行に変更
    - 従来のnext lintを実行するのはlint-nextにした
    - GitHub Actions で UnitTestを実行するときはlintとlint-nextを両方実施